### PR TITLE
fix: allow non-yarn package manager

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,7 @@
     "version": "standard-version",
     "reset": "git clean -dfx && git reset --hard && npm i",
     "clean": "trash build test",
-    "prepare-release": "run-s reset test cov:check doc:html version doc:publish",
-    "preinstall": "node -e \"if(process.env.npm_execpath.indexOf('yarn') === -1) throw new Error('redis-memoize-invalidate must be installed with Yarn: https://yarnpkg.com/')\""
+    "prepare-release": "run-s reset test cov:check doc:html version doc:publish"
   },
   "scripts-info": {
     "info": "Display information about the package scripts",


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Fix

* **What is the current behavior?** (You can also link to an open issue here)

memoredis cannot be installed by projects using npm

* **What is the new behavior (if this is a feature change)?**

memoredis has no opinions about how it is installed

* **Other information**:
